### PR TITLE
Serverless v0.4.5 => v0.5.5 用に改修

### DIFF
--- a/s-project.json
+++ b/s-project.json
@@ -1,7 +1,7 @@
 {
   "name": "serverless-web-monitor",
   "version": "0.0.1",
-  "profile": "serverless-v0.4.2",
+  "profile": "serverless-v0.5.5",
   "location": "https://github.com/azuchi/serverless-web-monitor",
   "author": "",
   "description": "A tool for website monitoring with Serverless Framework.",

--- a/sites/create/s-function.json
+++ b/sites/create/s-function.json
@@ -1,10 +1,13 @@
 {
   "name": "create",
+  "runtime": "nodejs",
+  "description": "Serverless Lambda function for project: serverless-web-monitor",
   "customName": false,
   "customRole": false,
   "handler": "create/handler.handler",
   "timeout": 6,
   "memorySize": 128,
+  "authorizer": {},
   "custom": {
     "excludePatterns": [],
     "envVars": []
@@ -15,6 +18,7 @@
       "method": "POST",
       "type": "AWS",
       "authorizationType": "none",
+      "authorizerFunction": false,
       "apiKeyRequired": false,
       "requestParameters": {},
       "requestTemplates": {
@@ -33,5 +37,14 @@
       }
     }
   ],
-  "events": []
+  "events": [],
+  "environment": {
+    "SERVERLESS_PROJECT": "${project}",
+    "SERVERLESS_STAGE": "${stage}",
+    "SERVERLESS_REGION": "${region}"
+  },
+  "vpc": {
+    "securityGroupIds": [],
+    "subnetIds": []
+  }
 }

--- a/sites/delete/s-function.json
+++ b/sites/delete/s-function.json
@@ -1,10 +1,13 @@
 {
   "name": "delete",
+  "runtime": "nodejs",
+  "description": "Serverless Lambda function for project: serverless-web-monitor",
   "customName": false,
   "customRole": false,
   "handler": "delete/handler.handler",
   "timeout": 6,
   "memorySize": 128,
+  "authorizer": {},
   "custom": {
     "excludePatterns": [],
     "envVars": []
@@ -15,6 +18,7 @@
       "method": "DELETE",
       "type": "AWS",
       "authorizationType": "none",
+      "authorizerFunction": false,
       "apiKeyRequired": false,
       "requestParameters": {},
       "requestTemplates": "$${apiRequestTemplate}",
@@ -33,5 +37,14 @@
       }
     }
   ],
-  "events": []
+  "events": [],
+  "environment": {
+    "SERVERLESS_PROJECT": "${project}",
+    "SERVERLESS_STAGE": "${stage}",
+    "SERVERLESS_REGION": "${region}"
+  },
+  "vpc": {
+    "securityGroupIds": [],
+    "subnetIds": []
+  }
 }

--- a/sites/delete/s-templates.json
+++ b/sites/delete/s-templates.json
@@ -1,0 +1,7 @@
+{
+  "apiRequestTemplate": {
+    "application/json": {
+      "pathId": "$input.params('id')"
+    }
+  }
+}

--- a/sites/index/s-function.json
+++ b/sites/index/s-function.json
@@ -1,10 +1,13 @@
 {
   "name": "index",
+  "runtime": "nodejs",
+  "description": "Serverless Lambda function for project: serverless-web-monitor",
   "customName": false,
   "customRole": false,
   "handler": "index/handler.handler",
   "timeout": 6,
   "memorySize": 128,
+  "authorizer": {},
   "custom": {
     "excludePatterns": [],
     "envVars": []
@@ -15,6 +18,7 @@
       "method": "GET",
       "type": "AWS",
       "authorizationType": "none",
+      "authorizerFunction": false,
       "apiKeyRequired": false,
       "requestParameters": {},
       "requestTemplates": {
@@ -35,5 +39,14 @@
       }
     }
   ],
-  "events": []
+  "events": [],
+  "environment": {
+    "SERVERLESS_PROJECT": "${project}",
+    "SERVERLESS_STAGE": "${stage}",
+    "SERVERLESS_REGION": "${region}"
+  },
+  "vpc": {
+    "securityGroupIds": [],
+    "subnetIds": []
+  }
 }

--- a/sites/lib/dynamo.js
+++ b/sites/lib/dynamo.js
@@ -8,7 +8,7 @@ const dynamoConfig = {
 };
 const docClient = new AWS.DynamoDB.DocumentClient(dynamoConfig);
 const stage = process.env.SERVERLESS_STAGE;
-const projectName = process.env.SERVERLESS_PROJECT_NAME;
+const projectName = process.env.SERVERLESS_PROJECT;
 const sitesTable = projectName + '-sites-' + stage;
 
 module.exports.createSite = function(site) {

--- a/sites/new/s-function.json
+++ b/sites/new/s-function.json
@@ -1,10 +1,13 @@
 {
   "name": "new",
+  "runtime": "nodejs",
+  "description": "Serverless Lambda function for project: serverless-web-monitor",
   "customName": false,
   "customRole": false,
   "handler": "new/handler.handler",
   "timeout": 6,
   "memorySize": 128,
+  "authorizer": {},
   "custom": {
     "excludePatterns": [],
     "envVars": []
@@ -15,6 +18,7 @@
       "method": "GET",
       "type": "AWS",
       "authorizationType": "none",
+      "authorizerFunction": false,
       "apiKeyRequired": false,
       "requestParameters": {},
       "requestTemplates": {
@@ -35,5 +39,14 @@
       }
     }
   ],
-  "events": []
+  "events": [],
+  "environment": {
+    "SERVERLESS_PROJECT": "${project}",
+    "SERVERLESS_STAGE": "${stage}",
+    "SERVERLESS_REGION": "${region}"
+  },
+  "vpc": {
+    "securityGroupIds": [],
+    "subnetIds": []
+  }
 }

--- a/sites/show/s-function.json
+++ b/sites/show/s-function.json
@@ -1,10 +1,13 @@
 {
   "name": "show",
+  "runtime": "nodejs",
+  "description": "Serverless Lambda function for project: serverless-web-monitor",
   "customName": false,
   "customRole": false,
   "handler": "show/handler.handler",
   "timeout": 6,
   "memorySize": 128,
+  "authorizer": {},
   "custom": {
     "excludePatterns": [],
     "envVars": []
@@ -15,6 +18,7 @@
       "method": "GET",
       "type": "AWS",
       "authorizationType": "none",
+      "authorizerFunction": false,
       "apiKeyRequired": false,
       "requestParameters": {},
       "requestTemplates": "$${apiRequestTemplate}",
@@ -33,5 +37,14 @@
       }
     }
   ],
-  "events": []
+  "events": [],
+  "environment": {
+    "SERVERLESS_PROJECT": "${project}",
+    "SERVERLESS_STAGE": "${stage}",
+    "SERVERLESS_REGION": "${region}"
+  },
+  "vpc": {
+    "securityGroupIds": [],
+    "subnetIds": []
+  }
 }

--- a/sites/show/s-templates.json
+++ b/sites/show/s-templates.json
@@ -1,0 +1,7 @@
+{
+  "apiRequestTemplate": {
+    "application/json": {
+      "pathId": "$input.params('id')"
+    }
+  }
+}

--- a/sites/trigger/s-function.json
+++ b/sites/trigger/s-function.json
@@ -1,10 +1,13 @@
 {
   "name": "trigger",
+  "runtime": "nodejs",
+  "description": "Serverless Lambda function for project: serverless-web-monitor",
   "customName": false,
   "customRole": false,
   "handler": "trigger/handler.handler",
   "timeout": 6,
   "memorySize": 128,
+  "authorizer": {},
   "custom": {
     "excludePatterns": [],
     "envVars": []
@@ -15,6 +18,7 @@
       "method": "GET",
       "type": "AWS",
       "authorizationType": "none",
+      "authorizerFunction": false,
       "apiKeyRequired": false,
       "requestParameters": {},
       "requestTemplates": {
@@ -35,5 +39,14 @@
       }
     }
   ],
-  "events": []
+  "events": [],
+  "environment": {
+    "SERVERLESS_PROJECT": "${project}",
+    "SERVERLESS_STAGE": "${stage}",
+    "SERVERLESS_REGION": "${region}"
+  },
+  "vpc": {
+    "securityGroupIds": [],
+    "subnetIds": []
+  }
 }


### PR DESCRIPTION
Serverless v0.5.5 がリリースされて、v0.4.5 からフレームワークの構造が変わっています。
- component の考え方が無くなった
- function 毎に runtime の記載が必要
  など

Serverless v0.5.5 の環境ではエラーで Deploy できなくなってしまったため、動くように改修しました。
