### PR TITLE
probe結果をDynamoDBへ登録し、SNSに通知する

### DIFF
--- a/s-resources-cf.json
+++ b/s-resources-cf.json
@@ -53,6 +53,13 @@
                 "lambda:InvokeFunction"
               ],
               "Resource": "arn:aws:lambda:${region}:*:*"
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "sns:Publish"
+              ],
+              "Resource": "arn:aws:sns:${region}:*:${project}-sites-${stage}"
             }
           ]
         },

--- a/sites/lib/dynamo.js
+++ b/sites/lib/dynamo.js
@@ -31,8 +31,10 @@ module.exports.getSites = function() {
     const params = {
       TableName: sitesTable,
       AttributesToGet: [
+        'id',
         'name',
-        'url'
+        'url',
+        'code'
       ]
     };
     docClient.scan(params, function(err, data) {

--- a/sites/lib/dynamo.js
+++ b/sites/lib/dynamo.js
@@ -41,3 +41,24 @@ module.exports.getSites = function() {
     });
   });
 };
+
+module.exports.updateSiteState = function(site) {
+  return new Promise(function(resolve, reject) {
+    const params = {
+      TableName: sitesTable,
+      Key: {
+        "id": site.site.id
+      },
+      UpdateExpression: "set code = :code",
+      ExpressionAttributeValues: {
+        ":code":site.code
+      },
+      ReturnValues:"UPDATED_NEW"
+    };
+    console.log("Updating site statusCode...");
+    docClient.update(params, function(err, data) {
+      if (err) return reject(err);
+      return resolve(data);
+    });
+  });
+};

--- a/sites/lib/lambda.js
+++ b/sites/lib/lambda.js
@@ -28,3 +28,20 @@ module.exports.checkSite = function(site) {
     return resolve('ok');
   });
 };
+
+module.exports.callSNS = function(message) {
+  return new Promise(function(resolve, reject) {
+    const params = {
+      FunctionName: projectName + '-sns',
+      InvocationType: 'Event',
+      LogType: 'Tail',
+      Payload: JSON.stringify(message)
+    }
+    console.log("Calling SNS function...");
+    lambda.invoke(params, function(err, data) {
+      if(err) console.log(err, err.stack);
+      else console.log("SNS function called successfully!");
+    });
+    return resolve('ok');
+  });
+};

--- a/sites/lib/sns.js
+++ b/sites/lib/sns.js
@@ -13,17 +13,18 @@ const snsTopicArn = process.env.SNS_TOPIC_ARN;
 
 module.exports.postSNS = function(msg) {
   return new Promise(function(resolve, reject) {
-    console.log(msg.Subject);
-    console.log(msg.Message);
     const params = {
       Message: msg.Message,
       Subject: msg.Subject,
       TopicArn: snsTopicArn
     };
+    console.log("Start SNS publish");
     sns.publish(params, function(err, data){
-      console.log(data);
-      if (err) return reject(err);
-      return resolve(data);
+      if (err) console.log(err, err.stack);
+      else {
+        console.log(data);
+        return resolve("ok");
+      }
     });
   });
 };

--- a/sites/probe/handler.js
+++ b/sites/probe/handler.js
@@ -2,32 +2,44 @@
 
 const rp = require('request-promise');
 const errors = require('request-promise/errors');
+const dynamo = require('../lib/dynamo');
 
 module.exports.handler = function(event, context, cb) {
-  rp({uri: event.url, resolveWithFullResponse: true}).then(function(response) {
-    const array = {
-      Date: response.headers.date,
-      Code: response.statusCode,
-      Message: response.statusMessage
-    };
+  return new Promise(function(resolve, reject) {
+    rp({uri: event.url, resolveWithFullResponse: true}).then(function(response) {
+      const statusCode = response.statusCode.toString(10);
+      const array = {
+        site: event,
+        date: response.headers.date,
+        code: statusCode,
+        message: response.statusMessage
+      };
+      return resolve(array);
+    }).catch(errors.StatusCodeError, function(error){
+      const statusCode = error.statusCode.toString(10);
+      const array = {
+        site: event,
+        date: error.response.headers.date,
+        code: statusCode,
+        message: error.error
+      };
+      return resolve(array);
+    }).catch(errors.RequestError, function(error){
+      const now = new Date().toUTCString();
+      const array = {
+        site: event,
+        date: now,
+        code: error.error.code,
+        message: error.message
+      };
+      return resolve(array);
+    });
+  }).then(function(array) {
     console.log(array);
-    return cb(null, array);
-  }).catch(errors.StatusCodeError, function(error){
-    const array = {
-      Date: error.response.headers.date,
-      Code: error.statusCode,
-      Msg: error.error
-    };
-    console.log(array);
-    return cb(null, array);
-  }).catch(errors.RequestError, function(error){
-    const now = new Date().toUTCString();
-    const array = {
-      Date: now,
-      Code: error.error.code,
-      Msg: error.message
-    };
-    console.log(array);
-    return cb(null, array);
+    if (event.code == undefined || event.code != array.code) {
+      console.log("Accessing DynamoDB...");
+      dynamo.updateSiteState(array);
+    }
+    return resolve(null, array);
   });
 };

--- a/sites/sns/handler.js
+++ b/sites/sns/handler.js
@@ -1,16 +1,19 @@
 'use strict';
 
 // Require Logic
-var sns = require('../lib/sns');
+const sns = require('../lib/sns');
 
 // Lambda Handler
-module.exports.handler = function(event, context) {
+module.exports.handler = function(event, context, cb) {
   console.log(event.data);
-  var params = event.data;
-  var msg = {
+  const params = event.data;
+  const msg = {
     "Subject": "[" + params['state'] + "] " + params['name'],
     "Message": params['state'] + ": " + params['name'] + "\n URL: " + params['url'] + "\n Reason: " + params['reason']
   }
   sns.postSNS(msg);
-  return context.done;
+
+  return cb(null, {
+    message: "SNS function executed!"
+  });
 }

--- a/sites/sns/handler.js
+++ b/sites/sns/handler.js
@@ -5,11 +5,13 @@ const sns = require('../lib/sns');
 
 // Lambda Handler
 module.exports.handler = function(event, context, cb) {
-  console.log(event.data);
-  const params = event.data;
+  console.log(event);
+  const params = event;
+  const site = event.site;
+
   const msg = {
-    "Subject": "[" + params['state'] + "] " + params['name'],
-    "Message": params['state'] + ": " + params['name'] + "\n URL: " + params['url'] + "\n Reason: " + params['reason']
+    "Subject": "Status changed to " + params['state'] + " - " + site['name'],
+    "Message": "Date: " + params['date'] + "\n" + "Current Status: " + params['state'] + "\n Name: " + site['name'] + "\n URL: " + site['url'] + "\n Response: " + params['code'] + " " + params['message']
   }
   sns.postSNS(msg);
 

--- a/sites/sns/s-function.json
+++ b/sites/sns/s-function.json
@@ -11,39 +11,6 @@
   "custom": {
     "excludePatterns": []
   },
-  "endpoints": [
-    {
-      "path": "sites/sns",
-      "method": "POST",
-      "type": "AWS",
-      "authorizationType": "none",
-      "authorizerFunction": false,
-      "apiKeyRequired": false,
-      "requestParameters": {},
-      "requestTemplates": {
-        "application/json": {
-          "body": "$input.json('$')",
-          "queryParams": "$input.params().querystring",
-          "pathParamas": "$input.params().path"
-        }
-      },
-      "responses": {
-        "400": {
-          "statusCode": "400"
-        },
-        "default": {
-          "statusCode": "200",
-          "responseParameters": {},
-          "responseModels": {
-            "application/json;charset=UTF-8": "Empty"
-          },
-          "responseTemplates": {
-            "application/json;charset=UTF-8": ""
-          }
-        }
-      }
-    }
-  ],
   "events": [],
   "environment": {
     "SERVERLESS_PROJECT": "${project}",


### PR DESCRIPTION
## trigger を叩いたときの一連の流れが完成
- trigger が叩かれると、DB に登録された site 毎に http/https リクエストを送信
- statusCode が変化していたら or 初めて取得したら、SNS に通知を送る
- 終わり
### statusCode を DynamoDB に登録する
- siteの状態が変わった時だけアクションを起こすため、前回の statusCode を DB に保持する
- DBの更新には登録された site の id が必要なため、これを取得するよう修正
- statusCode も同様に取得するように修正
### SNS に通知する機能
- statusCode が変化したら or 初めてリクエストを送ったら、結果を SNS に通知する
- SNS に publish する権限を追加
### SNS の endpoint を削除
- API として提供する必要がないため、endpoint を削除して普通の lambda 関数として使うよう変更
