### PR TITLE
triggerのAPI削除とhtmlのハイパーリンク調整

### DIFF
--- a/sites/create/handler.js
+++ b/sites/create/handler.js
@@ -11,7 +11,7 @@ module.exports.handler = function(event, context, cb) {
   console.log(site);
   dynamo.createSite(site).then(function(result){
     return cb(null, {
-      location: "/" + event.stage + "/sites/"
+      location: "sites/"
     });
   });
 };

--- a/sites/create/handler.js
+++ b/sites/create/handler.js
@@ -11,7 +11,7 @@ module.exports.handler = function(event, context, cb) {
   console.log(site);
   dynamo.createSite(site).then(function(result){
     return cb(null, {
-      location: "sites/"
+      location: "./"
     });
   });
 };

--- a/sites/index/index.html
+++ b/sites/index/index.html
@@ -15,7 +15,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="/<%= stage %>/sites"><span>Serverless Site Monitor</span></a>
+          <a class="navbar-brand" href="./"><span>Serverless Site Monitor</span></a>
         </div>
       </div>
     </div>
@@ -23,7 +23,7 @@
       <div class="container">
         <div class="row">
           <div class="col-md-12">
-            <a class="btn btn-primary" href="/<%= stage %>/sites/new">新規追加</a>
+            <a class="btn btn-primary" href="./new">新規追加</a>
           </div>
         </div>
         <div class="row">

--- a/sites/index/index.html
+++ b/sites/index/index.html
@@ -23,7 +23,7 @@
       <div class="container">
         <div class="row">
           <div class="col-md-12">
-            <a class="btn btn-primary" href="./new">新規追加</a>
+            <a class="btn btn-primary" href="./new/">新規追加</a>
           </div>
         </div>
         <div class="row">

--- a/sites/new/new.html
+++ b/sites/new/new.html
@@ -15,7 +15,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="/<%= stage %>/sites"><span>Serverless Site Monitor</span></a>
+          <a class="navbar-brand" href="../sites"><span>Serverless Site Monitor</span></a>
         </div>
       </div>
     </div>
@@ -23,7 +23,7 @@
       <div class="container">
         <div class="row">
           <div class="col-md-12">
-            <form class="form-horizontal" role="form" action="/<%= stage %>/sites" method="POST">
+            <form class="form-horizontal" role="form" action="../sites" method="POST">
               <div class="form-group">
                 <div class="col-sm-2">
                   <label for="name" class="control-label">Name</label>

--- a/sites/new/new.html
+++ b/sites/new/new.html
@@ -15,7 +15,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="../sites"><span>Serverless Site Monitor</span></a>
+          <a class="navbar-brand" href="../"><span>Serverless Site Monitor</span></a>
         </div>
       </div>
     </div>
@@ -23,7 +23,7 @@
       <div class="container">
         <div class="row">
           <div class="col-md-12">
-            <form class="form-horizontal" role="form" action="../sites" method="POST">
+            <form class="form-horizontal" role="form" action="../" method="POST">
               <div class="form-group">
                 <div class="col-sm-2">
                   <label for="name" class="control-label">Name</label>

--- a/sites/trigger/s-function.json
+++ b/sites/trigger/s-function.json
@@ -12,34 +12,16 @@
     "excludePatterns": [],
     "envVars": []
   },
-  "endpoints": [
+  "events": [
     {
-      "path": "sites/trigger",
-      "method": "GET",
-      "type": "AWS",
-      "authorizationType": "none",
-      "authorizerFunction": false,
-      "apiKeyRequired": false,
-      "requestParameters": {},
-      "requestTemplates": {
-        "application/json": ""
-      },
-      "responses": {
-        "400": {
-          "statusCode": "400"
-        },
-        "default": {
-          "statusCode": "200",
-          "responseParameters": {},
-          "responseModels": {},
-          "responseTemplates": {
-            "application/json": ""
-          }
-        }
+      "name": "triggerRoutine",
+      "type": "schedule",
+      "config": {
+        "schedule": "rate(5 minutes)",
+        "enabled": true
       }
     }
   ],
-  "events": [],
   "environment": {
     "SERVERLESS_PROJECT": "${project}",
     "SERVERLESS_STAGE": "${stage}",


### PR DESCRIPTION
### trigger API を削除
- trigger function を 5分毎に実行する event を追加
- endpoint(API) を削除
### htmlのハイパーリンク調整
- API Gateway のカスタムドメインを利用すると、ルートのパスが変わる
- リンクが切れるため、相対パスに変更
